### PR TITLE
fix: resume interrupted dumps by checking existing file size

### DIFF
--- a/external/libdumper/source/dump.cpp
+++ b/external/libdumper/source/dump.cpp
@@ -207,8 +207,7 @@ bool __dump(const Dumper_Options &options) {
 
   dumping_semaphore /= output_directory + ".dumping";
   if (std::filesystem::exists(dumping_semaphore, ec)) {
-    log_error("This dump is currently dumping or closed unexpectedly! Please "
-              "delete existing dump to enable dumping.");
+    log_info("Interrupted dump detected for %s, resuming...", title_id.c_str());
   }
 
   // Check for .complete semaphore

--- a/external/libdumper/source/pfs.cpp
+++ b/external/libdumper/source/pfs.cpp
@@ -29,14 +29,19 @@ namespace pfs {
         uint64_t bytes;
         uint64_t ix = 0;
         if(std::filesystem::exists(fname)){
-            log_debug("File already exists: %s", fname.c_str());
-            size -= bytes;
-            ix++;
-            pfs_copied += bytes;
-            if (pfs_copied > pfs_size) pfs_copied = pfs_size;
-            pfs_progress = (uint64_t)(((float)pfs_copied / pfs_size) * 100.f);
-            return;
-        }
+		uint64_t existing_size = std::filesystem::file_size(fname);
+    		if(existing_size == size) {
+        		log_debug("Skipping already complete file: %s (%llu bytes)", fname.c_str(), size);
+        		pfs_copied += size;
+        		if (pfs_copied > pfs_size) pfs_copied = pfs_size;
+        		pfs_progress = (uint64_t)(((float)pfs_copied / pfs_size) * 100.f);
+        		return;
+    		} else {
+			log_debug("Partial file detected, redumping: %s (has %llu, need %llu)", 
+                  		fname.c_str(), existing_size, size);
+        		std::filesystem::remove(fname);
+    		}
+	}
         int fd = sceKernelOpen(fname.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NONBLOCK, 0777);
         log_info("---- name: %s, ptr %p, sz %zu, FD: %i", fname.c_str(), ptr, size, fd);
         if (fd > 0)


### PR DESCRIPTION
## Problem
When a dump is interrupted (power loss, crash, etc.), restarting 
requires dumping the entire game from scratch even though most files 
were already copied to USB.

The existing file-exists check in pfs.cpp had an uninitialized 
variable bug — `bytes` was used before being assigned, causing 
incorrect progress accounting.

## Fix
- If a file already exists on USB and matches the expected size → skip it
- If a file exists but is smaller than expected (partial write) → delete and redo just that file
- All previously completed files are skipped correctly on resume

## Result
Interrupted dumps resume from where they stopped instead of 
restarting from 0%.

## Note
Untested on hardware due to lack of build environment. 
Logic reviewed carefully — looking for someone to verify on device.